### PR TITLE
feat: add final LLM filter stage (文献器) after rerank

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -953,26 +953,9 @@ export class RemoteLLM implements LLM {
     const model = options.model || oa.model || "gpt-4o-mini";
 
     const docsText = documents.map((doc, i) => `[${i}] ${doc.text}`).join("\n---\n");
-    const prompt = [
-      "你是记忆检索助手。根据查询从候选文档中筛选并提取相关信息。",
-      "",
-      `查询：${query}`,
-      "",
-      "候选文档：",
-      docsText,
-      "",
-      "规则：",
-      "1. 只提取与查询直接相关的文档内容，忽略不相关的",
-      "2. 每篇用 [编号] 开头，后面跟提取的核心内容",
-      "3. 用纯文本输出，不要JSON，不要markdown格式符",
-      "4. 没有相关文档则输出 NONE",
-      "5. 多篇文档内容相同或高度重复时，只提取第一篇，跳过后续重复",
-      "6. 优先选择原始数据源（如日记、笔记、配置记录），跳过「对话/搜索会话记录」类文档",
-      "",
-      "示例格式：",
-      "[0] 提取的核心内容",
-      "[3] 另一篇的核心内容",
-    ].join("\n");
+    // Load prompt template from ~/.config/qmd/rerank-prompt.txt if present.
+    // This allows iterating on extract behavior without changing code.
+    const prompt = buildRerankPrompt(query, docsText);
 
     const resp = await fetchWithRetry(`${baseUrl}/chat/completions`, {
       method: "POST",

--- a/src/store.ts
+++ b/src/store.ts
@@ -52,7 +52,9 @@ export const DEFAULT_MULTI_GET_MAX_BYTES = 10 * 1024; // 10KB
 
 // Chunking: configurable via QMD_CHUNK_SIZE_TOKENS and QMD_CHUNK_OVERLAP_TOKENS env vars
 export const CHUNK_SIZE_TOKENS = parseInt(process.env.QMD_CHUNK_SIZE_TOKENS || "200", 10);
-export const CHUNK_OVERLAP_TOKENS = parseInt(process.env.QMD_CHUNK_OVERLAP_TOKENS || "40", 10);
+// Clamp overlap to avoid zero/negative step (which can hang chunking loops)
+const _CHUNK_OVERLAP_TOKENS_RAW = parseInt(process.env.QMD_CHUNK_OVERLAP_TOKENS || "40", 10);
+export const CHUNK_OVERLAP_TOKENS = Math.max(0, Math.min(_CHUNK_OVERLAP_TOKENS_RAW, Math.max(0, CHUNK_SIZE_TOKENS - 1)));
 // Fallback char-based approximation for sync chunking (~4 chars per token)
 export const CHUNK_SIZE_CHARS = CHUNK_SIZE_TOKENS * 4;
 export const CHUNK_OVERLAP_CHARS = CHUNK_OVERLAP_TOKENS * 4;


### PR DESCRIPTION
### What
- Add optional final-stage LLM filter/extractor ("文献器") after cross-encoder rerank to select+extract relevant content, then surface extracted items first.
- Increase default `QMD_RERANK_DOC_LIMIT` in `QMD_RERANK_MODE=rerank` to 120 (keep 40 for LLM mode).
- Clamp `QMD_CHUNK_OVERLAP_TOKENS` to avoid zero/negative step (hang risk).

### How to enable
Set `QMD_LLM_FILTER_DOC_LIMIT` to a positive number (e.g. 40) and configure provider via existing `QMD_OPENAI_*` or `QMD_GEMINI_*` (or `QMD_LLM_FILTER_PROVIDER`).

### Notes
- Keeps non-extracted results as fallback (extracted items are moved to the top).
- Tests: `bun test`.